### PR TITLE
fix: expand explorer if currentPath is a dir

### DIFF
--- a/app/src/web/explorer/index.tsx
+++ b/app/src/web/explorer/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { websocketContext } from "../provider/context.ts";
 import { cn } from "../utils.ts";
 import { EntryComponent } from "./entry.tsx";
@@ -8,6 +8,11 @@ import { Header } from "./header.tsx";
 export const Explorer = () => {
     const { currentPath, isSingleFile } = useContext(websocketContext);
     const [isExpanded, setIsExpanded] = useState(false);
+
+    useEffect(() => {
+        const isDir = Boolean(currentPath?.endsWith("/"));
+        if (isDir) setIsExpanded(true);
+    }, [currentPath]);
 
     return (
         <div


### PR DESCRIPTION
The only way for currentPath to be a dir is if the user is navigating with the mouse on the browser using the explorer or if the user clicked on a breadcrumb. We expand explorer to allow the user to continue navigating using the mouse.