### PR TITLE
refactor(nvim-events): remove explicit event subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ Starts the service if not running or stops it if it's already running.
 
 ## Roadmap
 
+- [ ] set initial content or first render shows outdated content
+- [ ] disable srcoll & disable cursorline, how do these options interact with each other
 - [ ] fix line numbers in code files
+- [ ] keep track of open and closed \<details> every rerender
 - [ ] parse markdown in webworker (maybe?)
 - [ ] recalculate offsets on line count change (throttle maybe?)
 - [ ] implement link follow for local files

--- a/app/src/nvim-events/on-content-change.ts
+++ b/app/src/nvim-events/on-content-change.ts
@@ -18,9 +18,6 @@ export async function onContentChange(
         if (attachedBuffer === buffer) attachedBuffer = null;
     });
 
-    // Subscribe to RPCNotification
-    await nvim.call("nvim_subscribe", [NOTIFICATION]);
-
     // Notification handler
     nvim.onNotification(NOTIFICATION, async ([buffer, path]) => {
         if (!path) return;

--- a/app/src/nvim-events/on-cursor-move.ts
+++ b/app/src/nvim-events/on-cursor-move.ts
@@ -8,9 +8,6 @@ export async function onCursorMove(
     augroupId: number,
     callback: (args: CustomEvents["notifications"][typeof NOTIFICATION]) => Awaitable<void>,
 ) {
-    // Subscribe to RPCNotification
-    await nvim.call("nvim_subscribe", [NOTIFICATION]);
-
     // Notification handler
     nvim.onNotification(NOTIFICATION, callback);
 


### PR DESCRIPTION
there's no need to subscribe to events if "vim.rpcnotify" or "vim.rpcrequest" specify channel id