### PR TITLE
fix(cursorline): fix offsets being off when element height doesnt change

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -47,6 +47,7 @@ await onContentChange(app, (lines, path) => {
     const message: WsServerMessage = {
         type: "content-change",
         currentPath: relativePath,
+        linesCountChange: app.lines.length !== lines.length,
         lines,
     };
 

--- a/app/types.ts
+++ b/app/types.ts
@@ -106,6 +106,14 @@ export type WsServerMessage =
     | {
           type: "content-change";
           currentPath: string;
+          /**
+           * Offset recalculation is triggered on markdown container element resize.
+           * Sometimes adding new lines doesn't change the element size so offsets
+           * are not recalculated, leading to incorrect cursorline position.
+           * To fix that, we notify the browser on linesCountChange
+           * to trigger offset calculation.
+           * */
+          linesCountChange: boolean;
           lines: string[];
       }
     | {

--- a/app/web/components/markdown/index.tsx
+++ b/app/web/components/markdown/index.tsx
@@ -64,7 +64,13 @@ export const Markdown = ({ className }: { className: string }) => {
     }, []);
 
     useEffect(() => {
-        if (!markdownElement || !cursorLineElement || !lineNumbersElement) return;
+        if (
+            !markdownContainerElement ||
+            !markdownElement ||
+            !cursorLineElement ||
+            !lineNumbersElement
+        )
+            return;
         // const serializer = new XMLSerializer();
 
         registerHandler("markdown", async (message) => {
@@ -155,6 +161,10 @@ export const Markdown = ({ className }: { className: string }) => {
 
                 await runMermaid();
             }
+
+            if ("linesCountChange" in message && message.linesCountChange) {
+                setOffsets(getScrollOffsets(markdownContainerElement, markdownElement));
+            }
         });
     }, [
         registerHandler,
@@ -164,6 +174,7 @@ export const Markdown = ({ className }: { className: string }) => {
         markdownElement,
         cursorLineElement,
         lineNumbersElement,
+        markdownContainerElement,
     ]);
 
     useEffect(() => {


### PR DESCRIPTION
usually we trigger offset calculations on html element height change. sometimes we add new lines "\n" to the buffer, which doesn't increase the element height as markdown just eats the new lines and offsets become stale

re #110