### PR TITLE
fix(autoclose): open external links in new tab

### DIFF
--- a/app/web/components/markdown/index.tsx
+++ b/app/web/components/markdown/index.tsx
@@ -7,7 +7,7 @@ import { CURSOR_LINE_ELEMENT_ID, CursorLine } from "./cursor-line.tsx";
 import { Explorer } from "./explorer.tsx";
 import { LINE_NUMBERS_ELEMENT_ID, LineNumbers } from "./line-numbers.tsx";
 import { mermaidRun } from "./mermaid.ts";
-import { evalPantsdownScript, resolveRelativeLinks, updateElementsStyles } from "./post-process.ts";
+import { evalPantsdownScript, postProcessHrefs, updateElementsStyles } from "./post-process.ts";
 import { getScrollOffsets, type Offsets } from "./scroll.ts";
 
 const MARKDOWN_CONTAINER_ID = "markdown-container-id";
@@ -75,7 +75,7 @@ export const Markdown = ({ className }: { className: string }) => {
                     lineNumbersElement,
                 });
                 evalPantsdownScript(markdownElement);
-                resolveRelativeLinks({ wsRequest, markdownElement, skipScroll, single_file });
+                postProcessHrefs({ wsRequest, markdownElement, skipScroll, single_file });
                 await mermaidRun();
             }
 

--- a/app/web/components/markdown/post-process.ts
+++ b/app/web/components/markdown/post-process.ts
@@ -1,7 +1,7 @@
 import { type MutableRefObject } from "react";
 import { type WebsocketContext } from "../websocket-provider/context";
 
-export function resolveRelativeLinks({
+export function postProcessHrefs({
     wsRequest,
     markdownElement,
     skipScroll,
@@ -20,7 +20,12 @@ export function resolveRelativeLinks({
         const isAnchor = element.href
             .slice((window.location.origin + window.location.pathname).length)
             .startsWith("#");
+
         if (isAbsolute || isAnchor) {
+            if (isAbsolute) {
+                element.target = "_blank";
+                element.rel = "noreferrer noopener";
+            }
             return;
         }
 


### PR DESCRIPTION
open external links in new tab to prevent the navigation stack from changing. autoclose only works if navigation stack is empty

fix #157