### PR TITLE
fix(mermaid): properly update mermaid colors on theme change

### DIFF
--- a/app/web/components/markdown/mermaid.ts
+++ b/app/web/components/markdown/mermaid.ts
@@ -8,6 +8,7 @@ export const myMermaid = {
     mermaids: new Map<string, string>(),
 
     initialize(config: MermaidConfig) {
+        this.mermaids = new Map();
         mermaid.initialize(config);
     },
 


### PR DESCRIPTION
## Description

Since mermaids were being memoized, they would not rerender after a theme change. We now reset memoized mermaids if theme changes to force a rerender.

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
