### PR TITLE
Repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -7,34 +7,39 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
-  - type: input
-    id: plugin-manager
-    attributes:
-      label: Plugin Manager
-      description: What plugin manager are you using?
-    validations:
-      required: true
+  # - type: input
+  #   id: plugin-manager
+  #   attributes:
+  #     label: Plugin Manager
+  #     description: What plugin manager are you using?
+  #   validations:
+  #     required: true
   - type: textarea
     id: what-happened
     attributes:
       label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
+      description: Include any details you think might be relevant.
     validations:
       required: true
-  - type: dropdown
-    id: browsers
+  - type: textarea
+    id: what-is-expected
     attributes:
-      label: What browsers are you seeing the problem on?
-      multiple: true
-      options:
-        - Firefox
-        - Chrome
-        - Safari
-        - Microsoft Edge
-        - Other
+      label: How were you expecting the plugin to behave?
     validations:
       required: true
+  # - type: dropdown
+  #   id: browsers
+  #   attributes:
+  #     label: What browsers are you seeing the problem on?
+  #     multiple: true
+  #     options:
+  #       - Firefox
+  #       - Chrome
+  #       - Safari
+  #       - Microsoft Edge
+  #       - Other
+  #   validations:
+  #     required: true
   - type: textarea
     id: health
     attributes:

--- a/app/server/websocket.ts
+++ b/app/server/websocket.ts
@@ -33,7 +33,7 @@ export function websocketHandler(app: GithubPreview): WebSocketHandler {
             if (browserMessage.type === "init") {
                 // call "setCurrPath" in case app started in repository mode and no buffer
                 // was loaded. "setCurrPath" should resolve to readme.md if it exists.
-                await app.setCurrPath(app.currentPath);
+                const entries = await app.setCurrPath(app.currentPath);
 
                 const message: WsServerMessage = {
                     type: "init",
@@ -42,8 +42,8 @@ export function websocketHandler(app: GithubPreview): WebSocketHandler {
                     lines: app.lines,
                     config: app.config,
                     cursorLine: app.cursorLine,
+                    currentEntries: entries,
                 };
-
                 wsSend(message);
             }
 

--- a/app/types.ts
+++ b/app/types.ts
@@ -87,6 +87,7 @@ export type WsServerMessage =
           currentPath: string;
           config: GithubPreview["config"];
           cursorLine: number | null;
+          currentEntries: string[] | undefined;
       }
     | {
           type: "entries";

--- a/app/web/components/websocket-provider/provider.tsx
+++ b/app/web/components/websocket-provider/provider.tsx
@@ -22,7 +22,7 @@ export const WebsocketProvider = ({
     BUILD_CONSTS: { HOST, PORT, IS_DEV, THEME },
 }: Props) => {
     const [config, setConfig] = useState<GithubPreview["config"] | null>(null);
-    const [currentPath, setCurrentPath] = useState<string>("");
+    const [currentPath, setCurrentPath] = useState<string | null>(null);
     const handlers = useRef(new Map<string, MessageHandler>());
     const [repoName, setRepoName] = useState("");
 


### PR DESCRIPTION
## Description

Send currentEntries on "init" message in case plugin started in dir so we can render explorer in
markdown container

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
