### PR TITLE
fix(single-file): don't search for root if single-file mode is enabled

### DIFF
--- a/lua/github-preview/functions.lua
+++ b/lua/github-preview/functions.lua
@@ -5,12 +5,12 @@ M.start = function()
 	vim.notify("github-preview: init", vim.log.levels.INFO)
 
 	-- should look like "/Users/.../github-preview"
-	local root = vim.fn.finddir(".git", ";")
+	local root = Utils.config.single_file and "" or vim.fn.finddir(".git", ";")
 
 	local buffer_name = vim.api.nvim_buf_get_name(0)
 	local init_path = vim.fn.fnamemodify(buffer_name, ":p")
 
-	if root == "" or Utils.config.single_file then
+	if root == "" then
 		-- if repo root not found or single-file mode is enabled,
 		-- we make sure there's something loaded into the current buffer
 		if vim.fn.fnamemodify(init_path, ":t") == "" then
@@ -20,10 +20,8 @@ M.start = function()
 			)
 			return
 		end
-	end
 
-	if root == "" then
-		-- if root not found, we set root to current path
+		-- if no root, we set root to current path
 		root = vim.fn.fnamemodify(init_path, ":h") .. "/"
 		Utils.config.single_file = true
 	else


### PR DESCRIPTION
## Description

Even if single-file mode was enabled, we were still trying to find a git repository root. In some cases, depending on the cwd of the user, the search could take a while and it would seem like the app froze. Now if the user explicitly enabled single-file mode, we don't even try searching for a repository root.

re #249

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
