### PR TITLE
docs: add documenting comment

### DIFF
--- a/lua/github-preview/functions.lua
+++ b/lua/github-preview/functions.lua
@@ -37,6 +37,7 @@ M.start = function()
 		},
 		config = Utils.config,
 	}
+	-- vim.g.github_preview_props is read by bunvim
 	vim.g.github_preview_props = github_preview_props
 
 	local __filename = debug.getinfo(1, "S").source:sub(2)


### PR DESCRIPTION
## Description

Add comment to document why we set the variable, it's not obvious.

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
