### PR TITLE
refactor(types): rename lua type to something more specific

### DIFF
--- a/lua/github-preview/functions.lua
+++ b/lua/github-preview/functions.lua
@@ -30,7 +30,7 @@ M.start = function()
 		root = vim.fn.fnamemodify(root, ":p:h:h") .. "/"
 	end
 
-	---@type plugin_props
+	---@type github_preview_props
 	local github_preview_props = {
 		init = {
 			root = root,

--- a/lua/github-preview/types.lua
+++ b/lua/github-preview/types.lua
@@ -29,6 +29,6 @@
 ---@field scroll scroll | nil
 ---@field log_level nil | "verbose" | "debug"
 
----@class plugin_props
+---@class github_preview_props
 ---@field init init
 ---@field config github_preview_config


### PR DESCRIPTION
## Description

type may collide with some other plugin's that uses the same name

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
