### PR TITLE
ci(release): manually setup nodejs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,11 @@ jobs:
         uses: oven-sh/setup-bun@v1
       - name: Install dependencies
         run: bun install
+      - name: Setup node
+        # node needed or semantic-release complains
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

manually setup nodejs to fix semantic-release complaining about the included nodejs version

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
