### PR TITLE
ci(release): manually add nodejs to release github-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
       - name: Install bun
         uses: oven-sh/setup-bun@v1
       - name: Install dependencies
@@ -55,15 +59,14 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
       - name: Install bun
         uses: oven-sh/setup-bun@v1
       - name: Install dependencies
         run: bun install
-      - name: Setup node
-        # node needed or semantic-release complains
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

included version (16) is too low and some npm package complain

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
