### PR TITLE
ci(dependabot): run dependabot checks "montly" instead of "weekly"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 updates:
   - package-ecosystem: "npm"
     versioning-strategy: "increase"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
## Description

## Documentation

- [ ] If submitting/updating a feature, it has been documented in the appropriate places.
