### PR TITLE
fix(healthcheck): platform and commit sha fixes for windows

### DIFF
--- a/lua/github-preview/health.lua
+++ b/lua/github-preview/health.lua
@@ -59,8 +59,7 @@ local function check_bun_version()
 end
 
 local function check_current_commit_hash()
-	local result =
-		run_command("git -C $(dirname " .. vim.fn.shellescape(vim.fn.expand("%:p")) .. ") rev-parse --short HEAD")
+	local result = run_command("git -C " .. debug.getinfo(1).source:sub(2):match("(.*/)") .. " rev-parse --short HEAD")
 	if result == nil then
 		vim.health.error("failed to read git-commit hash")
 	else

--- a/lua/github-preview/health.lua
+++ b/lua/github-preview/health.lua
@@ -3,7 +3,7 @@ local M = {}
 local function check_platform()
 	local function get_platform()
 		local os_name = vim.loop.os_uname().sysname
-		if os_name == "Windows" then
+		if os_name == "Windows_NT" then
 			return "win"
 		elseif os_name == "Darwin" then
 			local arch = vim.fn.system("arch")


### PR DESCRIPTION
## Description

This PR fixes two health check functions that are currently broken on Windows:
1. **Platform:** `vim.loop.os_uname().sysname` returns `"Windows_NT"` on Windows, so this was a nice, quick and easy fix.
2. **Commit Hash:** Now using a pure Lua method to get the plugin directory rather than relying on the shell. 

Before:
![image](https://github.com/wallpants/github-preview.nvim/assets/39483124/074a37ba-aea7-4c73-8908-06a89b36c06e)

After:
![image](https://github.com/wallpants/github-preview.nvim/assets/39483124/06153b68-85ea-4021-afe9-51d776911dfd)

SHA of fork:
![image](https://github.com/wallpants/github-preview.nvim/assets/39483124/2f813b4f-3176-483a-9c0c-cf732411a1c2)

I've also verified that this still works on Linux (Ubuntu on WSL):
![image](https://github.com/wallpants/github-preview.nvim/assets/39483124/6faf750d-ca28-4711-b499-a2fb47b5683a)

