### PR TITLE
fix(http-server): remove empty headers object

### DIFF
--- a/app/server/http.ts
+++ b/app/server/http.ts
@@ -21,10 +21,7 @@ const mockCssLoader: BunPlugin = {
 
 export function httpHandler(app: GithubPreview) {
     return async (req: Request, server: Server) => {
-        const upgradedToWs = server.upgrade(req, {
-            data: {}, // this data is available in socket.data
-            headers: {},
-        });
+        const upgradedToWs = server.upgrade(req);
         if (upgradedToWs) {
             // If client (browser) requested to upgrade connection to websocket
             // and we successfully upgraded request


### PR DESCRIPTION
## Description

Bun is throwing an error saying that 'headers' must be an object, which it already is. Removing the declaration seems to be fixing the error.

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
