### PR TITLE
fix(bun): notify user when bun is not installed

### DIFF
--- a/lua/github-preview/functions.lua
+++ b/lua/github-preview/functions.lua
@@ -3,6 +3,14 @@ local Utils = require("github-preview.utils")
 local M = {}
 
 M.start = function()
+	if vim.fn.executable("bun") ~= 1 then
+		vim.notify(
+			"[github-preview.nvim] bun is required but was not found in PATH. Install it from https://bun.sh",
+			vim.log.levels.ERROR
+		)
+		return
+	end
+
 	vim.notify("github-preview: init", vim.log.levels.INFO)
 
 	-- should look like "/Users/.../github-preview"


### PR DESCRIPTION
## Problem

When bun is not installed, running `GithubPreviewToggle` silently fails. `jobstart` returns without error and produces no visible output, leaving the user with no indication of what went wrong.

## Solution

Check `vim.fn.executable("bun")` at the top of `start()` and show an `ERROR`-level notification with install instructions before any jobs are spawned.