### PR TITLE
fix(notify): remove INFO notifications that block cmdheight=0

### DIFF
--- a/app/github-preview.ts
+++ b/app/github-preview.ts
@@ -204,7 +204,7 @@ export class GithubPreview {
     async goodbye() {
         this.wsSend({ type: "goodbye" });
         await this.nvim.call("nvim_del_augroup_by_id", [this.augroupId]);
-        await this.nvim.call("nvim_notify", ["github-preview: goodbye", NVIM_LOG_LEVELS.INFO, {}]);
+        await this.nvim.call("nvim_echo", [[["github-preview: goodbye", ""]], false, {}]);
     }
 
     async updateConfig([action, value]: UpdateConfigAction) {

--- a/lua/github-preview/functions.lua
+++ b/lua/github-preview/functions.lua
@@ -3,8 +3,6 @@ local Utils = require("github-preview.utils")
 local M = {}
 
 M.start = function()
-	vim.notify("github-preview: init", vim.log.levels.INFO)
-
 	-- should look like "/Users/.../github-preview"
 	local root = Config.value.single_file and "" or vim.fn.finddir(".git", ";")
 


### PR DESCRIPTION
## Problem

`vim.notify` at INFO level writes to the command line area. With `cmdheight=0` there is no space for it, so Neovim forces a "Press ENTER" prompt on every `:GithubPreviewStart` and `:GithubPreviewStop`.

## Solution

Remove the redundant "init" notification entirely (the browser opening is confirmation enough) and switch the "goodbye" notification to `nvim_echo` with `history=false` so it displays transiently without requiring command line space.