### PR TITLE
fix(nvim-events): skip notifications for non-file buffers

### DIFF
--- a/app/nvim/on-content-change.ts
+++ b/app/nvim/on-content-change.ts
@@ -37,9 +37,12 @@ export async function onContentChange(
             group: app.augroupId,
             desc: "Notify github-preview",
             command: `lua
-            local buffer = vim.api.nvim_get_current_buf()
-            local path = vim.api.nvim_buf_get_name(0)
-            vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path)`,
+            if vim.bo.buftype == "" then
+                local buffer = vim.api.nvim_get_current_buf()
+                local path = vim.api.nvim_buf_get_name(0)
+                vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path)
+            end`,
+
         },
     ]);
 

--- a/app/nvim/on-cursor-move.ts
+++ b/app/nvim/on-cursor-move.ts
@@ -18,10 +18,12 @@ export async function onCursorMove(
             group: app.augroupId,
             desc: "Notify github-preview",
             command: `lua
-            local buffer = vim.api.nvim_get_current_buf()
-            local path = vim.api.nvim_buf_get_name(0)
-            local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
-            vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path, cursor_line)`,
+                if vim.bo.buftype == "" then
+                    local buffer = vim.api.nvim_get_current_buf()
+                    local path = vim.api.nvim_buf_get_name(0)
+                    local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
+                    vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path, cursor_line)
+                end`,
         },
     ]);
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where the previewer attempts to resolve and process paths for "special" buffers (e.g., mini.files, Telescope, NvimTree). Previously, these buffers triggered autocommands that sent invalid paths (like minifiles://...) to the Bun server, resulting in "Path not found" errors in the previewer.

## Documentation

- [ ] If submitting/updating a feature, it has been documented in the appropriate places.
