### PR TITLE
fix(nvim-events): skip notifications for non-file buffers

### DIFF
--- a/app/nvim/on-content-change.ts
+++ b/app/nvim/on-content-change.ts
@@ -30,18 +30,21 @@ export async function onContentChange(
       }
    });
 
-   // Create autocmd to notify us with event "attach_buffer"
-   await app.nvim.call("nvim_create_autocmd", [
-      ["InsertEnter", "TextChanged"],
-      {
-         group: app.augroupId,
-         desc: "Notify github-preview",
-         command: `lua
-            local buffer = vim.api.nvim_get_current_buf()
-            local path = vim.api.nvim_buf_get_name(0)
-            vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path)`,
-      },
-   ]);
+    // Create autocmd to notify us with event "attach_buffer"
+    await app.nvim.call("nvim_create_autocmd", [
+        ["InsertEnter", "TextChanged"],
+        {
+            group: app.augroupId,
+            desc: "Notify github-preview",
+            command: `lua
+            local buftype = vim.api.nvim_get_option_value("buftype", { buf = 0 })
+            if buftype == "" then
+                local buffer = vim.api.nvim_get_current_buf()
+                local path = vim.api.nvim_buf_get_name(0)
+                vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path)
+            end`,
+        },
+    ]);
 
    // "nvim_buf_lines_event" and "nvim_buf_changedtick_event" events are
    // only emitted by neovim if we've attached a buffer.

--- a/app/nvim/on-content-change.ts
+++ b/app/nvim/on-content-change.ts
@@ -30,21 +30,21 @@ export async function onContentChange(
       }
    });
 
-    // Create autocmd to notify us with event "attach_buffer"
-    await app.nvim.call("nvim_create_autocmd", [
-        ["InsertEnter", "TextChanged"],
-        {
-            group: app.augroupId,
-            desc: "Notify github-preview",
-            command: `lua
+   // Create autocmd to notify us with event "attach_buffer"
+   await app.nvim.call("nvim_create_autocmd", [
+      ["InsertEnter", "TextChanged"],
+      {
+         group: app.augroupId,
+         desc: "Notify github-preview",
+         command: `lua
             local buftype = vim.api.nvim_get_option_value("buftype", { buf = 0 })
             if buftype == "" then
-                local buffer = vim.api.nvim_get_current_buf()
-                local path = vim.api.nvim_buf_get_name(0)
-                vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path)
+               local buffer = vim.api.nvim_get_current_buf()
+               local path = vim.api.nvim_buf_get_name(0)
+               vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path)
             end`,
-        },
-    ]);
+      },
+   ]);
 
    // "nvim_buf_lines_event" and "nvim_buf_changedtick_event" events are
    // only emitted by neovim if we've attached a buffer.

--- a/app/nvim/on-content-change.ts
+++ b/app/nvim/on-content-change.ts
@@ -37,9 +37,12 @@ export async function onContentChange(
             group: app.augroupId,
             desc: "Notify github-preview",
             command: `lua
-            local buffer = vim.api.nvim_get_current_buf()
-            local path = vim.api.nvim_buf_get_name(0)
-            vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path)`,
+            local buftype = vim.api.nvim_get_option_value("buftype", { buf = 0 })
+            if buftype == "" then
+                local buffer = vim.api.nvim_get_current_buf()
+                local path = vim.api.nvim_buf_get_name(0)
+                vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path)
+            end`,
         },
     ]);
 

--- a/app/nvim/on-cursor-move.ts
+++ b/app/nvim/on-cursor-move.ts
@@ -11,20 +11,20 @@ export async function onCursorMove(
    // Notification handler
    app.nvim.onNotification(NOTIFICATION, callback);
 
-    // Create autocmd to notify us with event "CursorMove"
-    await app.nvim.call("nvim_create_autocmd", [
-        ["CursorHold", "CursorHoldI"],
-        {
-            group: app.augroupId,
-            desc: "Notify github-preview",
-            command: `lua
-                local buftype = vim.api.nvim_get_option_value("buftype", { buf = 0 })
-                if buftype == "" then
-                    local buffer = vim.api.nvim_get_current_buf()
-                    local path = vim.api.nvim_buf_get_name(0)
-                    local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
-                    vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path, cursor_line)
-                end`,
-        },
-    ]);
+   // Create autocmd to notify us with event "CursorMove"
+   await app.nvim.call("nvim_create_autocmd", [
+      ["CursorHold", "CursorHoldI"],
+      {
+         group: app.augroupId,
+         desc: "Notify github-preview",
+         command: `lua
+            local buftype = vim.api.nvim_get_option_value("buftype", { buf = 0 })
+            if buftype == "" then
+               local buffer = vim.api.nvim_get_current_buf()
+               local path = vim.api.nvim_buf_get_name(0)
+               local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
+               vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path, cursor_line)
+            end`,
+      },
+   ]);
 }

--- a/app/nvim/on-cursor-move.ts
+++ b/app/nvim/on-cursor-move.ts
@@ -11,17 +11,20 @@ export async function onCursorMove(
    // Notification handler
    app.nvim.onNotification(NOTIFICATION, callback);
 
-   // Create autocmd to notify us with event "CursorMove"
-   await app.nvim.call("nvim_create_autocmd", [
-      ["CursorHold", "CursorHoldI"],
-      {
-         group: app.augroupId,
-         desc: "Notify github-preview",
-         command: `lua
-            local buffer = vim.api.nvim_get_current_buf()
-            local path = vim.api.nvim_buf_get_name(0)
-            local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
-            vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path, cursor_line)`,
-      },
-   ]);
+    // Create autocmd to notify us with event "CursorMove"
+    await app.nvim.call("nvim_create_autocmd", [
+        ["CursorHold", "CursorHoldI"],
+        {
+            group: app.augroupId,
+            desc: "Notify github-preview",
+            command: `lua
+                local buftype = vim.api.nvim_get_option_value("buftype", { buf = 0 })
+                if buftype == "" then
+                    local buffer = vim.api.nvim_get_current_buf()
+                    local path = vim.api.nvim_buf_get_name(0)
+                    local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
+                    vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path, cursor_line)
+                end`,
+        },
+    ]);
 }

--- a/app/nvim/on-cursor-move.ts
+++ b/app/nvim/on-cursor-move.ts
@@ -18,10 +18,13 @@ export async function onCursorMove(
             group: app.augroupId,
             desc: "Notify github-preview",
             command: `lua
-            local buffer = vim.api.nvim_get_current_buf()
-            local path = vim.api.nvim_buf_get_name(0)
-            local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
-            vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path, cursor_line)`,
+                local buftype = vim.api.nvim_get_option_value("buftype", { buf = 0 })
+                if buftype == "" then
+                    local buffer = vim.api.nvim_get_current_buf()
+                    local path = vim.api.nvim_buf_get_name(0)
+                    local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
+                    vim.rpcnotify(${app.nvim.channelId}, "${NOTIFICATION}", buffer, path, cursor_line)
+                end`,
         },
     ]);
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where the previewer attempts to resolve and process paths for "special" buffers (e.g., mini.files, Telescope, NvimTree). Previously, these buffers triggered autocommands that sent invalid paths (like minifiles://...) to the Bun server, resulting in "Path not found" errors in the previewer.

Checks for buftype using neovim api.

## Documentation

- [ ] If submitting/updating a feature, it has been documented in the appropriate places.
