### PR TITLE
Fix: codeblocks inside alerts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "isbinaryfile": "6.0.0",
         "mermaid": "^11.16.0",
         "opener": "^1.5.2",
-        "pantsdown": "2.3.0",
+        "pantsdown": "2.3.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "reconnecting-websocket": "^4.4.0",
@@ -988,7 +988,7 @@
 
     "package-manager-detector": ["package-manager-detector@1.7.0", "", {}, "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ=="],
 
-    "pantsdown": ["pantsdown@2.3.0", "", { "dependencies": { "github-slugger": "^2.0.0", "highlight.js": "^11.11.1", "katex": "^0.18.1" } }, "sha512-pkAfc4FraYphkalL0HYmLxJUZ4M/mC3hW82vm+7gbfEqsuYbPrx09RvCxFcCyryPpO9eyV57QSvFZ6RK66eioA=="],
+    "pantsdown": ["pantsdown@2.3.2", "", { "dependencies": { "github-slugger": "^2.0.0", "highlight.js": "^11.11.1", "katex": "^0.18.1" } }, "sha512-oDFUbk7iwFYaYl7K6i1HcMa2s371NpKHrnUVpJ/Y4ACMERxVTjoBtyDZOQjafcjZEsQqbE9kMxHZ99/9V+kJGw=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -117,10 +117,10 @@ If you specified a `log_level`, hot-reload will be enabled for both changes to t
 
 ## Formatting and Linting
 
-This project uses [prettier](https://prettier.io/) and [eslint](https://eslint.org/)
+This project uses [oxfmt](https://oxc.rs/docs/guide/usage/formatter) and [oxlint](https://oxc.rs/docs/guide/usage/linter)
 to enforce coding style and quality standards.
 
-Make sure to set them up in your editor. You can configure **prettier** to
+Make sure to set them up in your editor. You can configure **oxfmt** to
 _format on save_ or you can manually run the following **package.json**
 script to format files:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -81,7 +81,9 @@ https://github.com/wallpants/github-preview.nvim/assets/47203170/092a4658-6f74-4
 
 ## 🧜 Mermaid Support
 
-Basic [mermaid](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) support.
+[Mermaid](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) support.
+
+Rendered diagrams are interactive: `cmd/ctrl + drag` pans, `cmd/ctrl + scroll` zooms.
 
 The following block would result in the svg below.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "isbinaryfile": "6.0.0",
     "mermaid": "^11.16.0",
     "opener": "^1.5.2",
-    "pantsdown": "2.3.0",
+    "pantsdown": "2.3.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "reconnecting-websocket": "^4.4.0",


### PR DESCRIPTION
## Description

codeblocks inside alerts were getting their whitespaces stripped. The new pantsdown version fixes that.

## Documentation

- [x] If submitting/updating a feature, it has been documented in the appropriate places.
